### PR TITLE
KQL Sysmon Parser and Jinja Template

### DIFF
--- a/resources/parsers/SysmonKQLParserV12.0.txt
+++ b/resources/parsers/SysmonKQLParserV12.0.txt
@@ -1,5 +1,5 @@
 // KQL Sysmon Event Parser
-// Last Updated Date: 2020-09-17
+// Last Updated Date: 2021-02-23
 // Sysmon Version: 12.0, Binary Version : 11.0, Schema Version: 4.40
 //
 // Authors:
@@ -8,212 +8,577 @@
 let EventData = Event
 | where Source == "Microsoft-Windows-Sysmon"
 | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+| project TimeGenerated,
+    Source,
+    EventID,
+    Computer,
+    UserName,
+    EventData,
+    RenderedDescription
 | extend EvData = parse_xml(EventData)
 | extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
-;
+| project-away EventData,
+    EvData;
+// Event ID 255
+//--------------------------
 let SYSMON_ERROR_255=() {
 let processEvents = EventData
 | where EventID == 255
-| extend UtcTime = EventDetail.[0].["#text"], ID = EventDetail.[1].["#text"], Description = EventDetail.[2].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+ID = EventDetail.[1].["#text"], 
+Description = EventDetail.[2].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 1
+//--------------------------
 let SYSMON_CREATE_PROCESS_1=() {
 let processEvents = EventData
 | where EventID == 1
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], Company = EventDetail.[8].["#text"], OriginalFileName = EventDetail.[9].["#text"], CommandLine = EventDetail.[10].["#text"], CurrentDirectory = EventDetail.[11].["#text"], User = EventDetail.[12].["#text"], LogonGuid = EventDetail.[13].["#text"], LogonId = EventDetail.[14].["#text"], TerminalSessionId = EventDetail.[15].["#text"], IntegrityLevel = EventDetail.[16].["#text"], Hashes = EventDetail.[17].["#text"], ParentProcessGuid = EventDetail.[18].["#text"], ParentProcessId = EventDetail.[19].["#text"], ParentImage = EventDetail.[20].["#text"], ParentCommandLine = EventDetail.[21].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+FileVersion = EventDetail.[5].["#text"], 
+Description = EventDetail.[6].["#text"], 
+Product = EventDetail.[7].["#text"], 
+Company = EventDetail.[8].["#text"], 
+OriginalFileName = EventDetail.[9].["#text"], 
+CommandLine = EventDetail.[10].["#text"], 
+CurrentDirectory = EventDetail.[11].["#text"], 
+User = EventDetail.[12].["#text"], 
+LogonGuid = EventDetail.[13].["#text"], 
+LogonId = EventDetail.[14].["#text"], 
+TerminalSessionId = EventDetail.[15].["#text"], 
+IntegrityLevel = EventDetail.[16].["#text"], 
+ParentProcessGuid = EventDetail.[18].["#text"], 
+ParentProcessId = EventDetail.[19].["#text"], 
+ParentImage = EventDetail.[20].["#text"], 
+ParentCommandLine = EventDetail.[21].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[17].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 2
+//--------------------------
 let SYSMON_FILE_TIME_2=() {
 let processEvents = EventData
 | where EventID == 2
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"], 
+PreviousCreationUtcTime = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 3
+//--------------------------
 let SYSMON_NETWORK_CONNECT_3=() {
 let processEvents = EventData
 | where EventID == 3
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], DestinationIp = EventDetail.[14].["#text"], DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+User = EventDetail.[5].["#text"], 
+Protocol = EventDetail.[6].["#text"], 
+Initiated = EventDetail.[7].["#text"], 
+SourceIsIpv6 = EventDetail.[8].["#text"], 
+SourceIp = EventDetail.[9].["#text"], 
+SourceHostname = EventDetail.[10].["#text"], 
+SourcePort = EventDetail.[11].["#text"], 
+SourcePortName = EventDetail.[12].["#text"], 
+DestinationIsIpv6 = EventDetail.[13].["#text"], 
+DestinationIp = EventDetail.[14].["#text"], 
+DestinationHostname = EventDetail.[15].["#text"], 
+DestinationPort = EventDetail.[16].["#text"], 
+DestinationPortName = EventDetail.[17].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 4
+//--------------------------
 let SYSMON_SERVICE_STATE_CHANGE_4=() {
 let processEvents = EventData
 | where EventID == 4
-| extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Version = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+State = EventDetail.[1].["#text"], 
+Version = EventDetail.[2].["#text"], 
+SchemaVersion = EventDetail.[3].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 5
+//--------------------------
 let SYSMON_PROCESS_TERMINATE_5=() {
 let processEvents = EventData
 | where EventID == 5
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 6
+//--------------------------
 let SYSMON_DRIVER_LOAD_6=() {
 let processEvents = EventData
 | where EventID == 6
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"], Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ImageLoaded = EventDetail.[2].["#text"], 
+Signed = EventDetail.[4].["#text"], 
+Signature = EventDetail.[5].["#text"], 
+SignatureStatus = EventDetail.[6].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[3].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 7
+//--------------------------
 let SYSMON_IMAGE_LOAD_7=() {
 let processEvents = EventData
 | where EventID == 7
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], OriginalFileName = EventDetail.[10].["#text"], Hashes = EventDetail.[11].["#text"], Signed = EventDetail.[12].["#text"], Signature = EventDetail.[13].["#text"], SignatureStatus = EventDetail.[14].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+ImageLoaded = EventDetail.[5].["#text"], 
+FileVersion = EventDetail.[6].["#text"], 
+Description = EventDetail.[7].["#text"], 
+Product = EventDetail.[8].["#text"], 
+Company = EventDetail.[9].["#text"], 
+OriginalFileName = EventDetail.[10].["#text"], 
+Signed = EventDetail.[12].["#text"], 
+Signature = EventDetail.[13].["#text"], 
+SignatureStatus = EventDetail.[14].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[11].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 8
+//--------------------------
 let SYSMON_CREATE_REMOTE_THREAD_8=() {
 let processEvents = EventData
 | where EventID == 8
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"], NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+SourceProcessGuid = EventDetail.[2].["#text"], 
+SourceProcessId = EventDetail.[3].["#text"], 
+SourceImage = EventDetail.[4].["#text"], 
+TargetProcessGuid = EventDetail.[5].["#text"], 
+TargetProcessId = EventDetail.[6].["#text"], 
+TargetImage = EventDetail.[7].["#text"], 
+NewThreadId = EventDetail.[8].["#text"], 
+StartAddress = EventDetail.[9].["#text"], 
+StartModule = EventDetail.[10].["#text"], 
+StartFunction = EventDetail.[11].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 9
+//--------------------------
 let SYSMON_RAWACCESS_READ_9=() {
 let processEvents = EventData
 | where EventID == 9
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+Device = EventDetail.[5].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 10
+//--------------------------
 let SYSMON_ACCESS_PROCESS_10=() {
 let processEvents = EventData
 | where EventID == 10
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+SourceProcessGUID = EventDetail.[2].["#text"], 
+SourceProcessId = EventDetail.[3].["#text"], 
+SourceThreadId = EventDetail.[4].["#text"], 
+SourceImage = EventDetail.[5].["#text"], 
+TargetProcessGUID = EventDetail.[6].["#text"], 
+TargetProcessId = EventDetail.[7].["#text"], 
+TargetImage = EventDetail.[8].["#text"], 
+GrantedAccess = EventDetail.[9].["#text"], 
+CallTrace = EventDetail.[10].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 11
+//--------------------------
 let SYSMON_FILE_CREATE_11=() {
 let processEvents = EventData
 | where EventID == 11
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 12
+//--------------------------
 let SYSMON_REG_KEY_12=() {
 let processEvents = EventData
 | where EventID == 12
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 13
+//--------------------------
 let SYSMON_REG_SETVALUE_13=() {
 let processEvents = EventData
 | where EventID == 13
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"], 
+Details = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 14
+//--------------------------
 let SYSMON_REG_NAME_14=() {
 let processEvents = EventData
 | where EventID == 14
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"], 
+NewName = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 15
+//--------------------------
 let SYSMON_FILE_CREATE_STREAM_HASH_15=() {
 let processEvents = EventData
 | where EventID == 15
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"], Contents = EventDetail.[8].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"], 
+Hash = EventDetail.[7].["#text"], 
+Contents = EventDetail.[8].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 16
+//--------------------------
 let SYSMON_SERVICE_CONFIGURATION_CHANGE_16=() {
 let processEvents = EventData
 | where EventID == 16
-| extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+Configuration = EventDetail.[1].["#text"], 
+ConfigurationFileHash = EventDetail.[2].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 17
+//--------------------------
 let SYSMON_CREATE_NAMEDPIPE_17=() {
 let processEvents = EventData
 | where EventID == 17
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+PipeName = EventDetail.[5].["#text"], 
+Image = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 18
+//--------------------------
 let SYSMON_CONNECT_NAMEDPIPE_18=() {
 let processEvents = EventData
 | where EventID == 18
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+PipeName = EventDetail.[5].["#text"], 
+Image = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 19
+//--------------------------
 let SYSMON_WMI_FILTER_19=() {
 let processEvents = EventData
 | where EventID == 19
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+EventNamespace = EventDetail.[5].["#text"], 
+Name = EventDetail.[6].["#text"], 
+Query = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 20
+//--------------------------
 let SYSMON_WMI_CONSUMER_20=() {
 let processEvents = EventData
 | where EventID == 20
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Name = EventDetail.[5].["#text"], Type = EventDetail.[6].["#text"], Destination = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Name = EventDetail.[5].["#text"], 
+Type = EventDetail.[6].["#text"], 
+Destination = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 21
+//--------------------------
 let SYSMON_WMI_BINDING_21=() {
 let processEvents = EventData
 | where EventID == 21
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Consumer = EventDetail.[5].["#text"], 
+Filter = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 22
+//--------------------------
 let SYSMON_DNS_QUERY_22=() {
 let processEvents = EventData
 | where EventID == 22
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], QueryName = EventDetail.[4].["#text"], QueryStatus = EventDetail.[5].["#text"], QueryResults = EventDetail.[6].["#text"], Image = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+QueryName = EventDetail.[4].["#text"], 
+QueryStatus = EventDetail.[5].["#text"], 
+QueryResults = EventDetail.[6].["#text"], 
+Image = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 23
+//--------------------------
 let SYSMON_FILE_DELETE_23=() {
 let processEvents = EventData
 | where EventID == 23
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetFilename = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], IsExecutable = EventDetail.[8].["#text"], Archived = EventDetail.[9].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetFilename = EventDetail.[6].["#text"], 
+IsExecutable = EventDetail.[8].["#text"], 
+Archived = EventDetail.[9].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 24
+//--------------------------
 let SYSMON_CLIPBOARD_24=() {
 let processEvents = EventData
 | where EventID == 24
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Session = EventDetail.[5].["#text"], ClientInfo = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], Archived = EventDetail.[8].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+Session = EventDetail.[5].["#text"], 
+ClientInfo = EventDetail.[6].["#text"], 
+Archived = EventDetail.[8].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
 (union isfuzzy=true
-SYSMON_ERROR_255, SYSMON_CREATE_PROCESS_1, SYSMON_FILE_TIME_2, SYSMON_NETWORK_CONNECT_3, SYSMON_SERVICE_STATE_CHANGE_4, SYSMON_PROCESS_TERMINATE_5, SYSMON_DRIVER_LOAD_6, SYSMON_IMAGE_LOAD_7, SYSMON_CREATE_REMOTE_THREAD_8, SYSMON_RAWACCESS_READ_9, SYSMON_ACCESS_PROCESS_10, SYSMON_FILE_CREATE_11, SYSMON_REG_KEY_12, SYSMON_REG_SETVALUE_13, SYSMON_REG_NAME_14, SYSMON_FILE_CREATE_STREAM_HASH_15, SYSMON_SERVICE_CONFIGURATION_CHANGE_16, SYSMON_CREATE_NAMEDPIPE_17, SYSMON_CONNECT_NAMEDPIPE_18, SYSMON_WMI_FILTER_19, SYSMON_WMI_CONSUMER_20, SYSMON_WMI_BINDING_21, SYSMON_DNS_QUERY_22, SYSMON_FILE_DELETE_23, SYSMON_CLIPBOARD_24)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
-| project EventID, UtcTime, ID, Description, RuleName, ProcessGuid, ProcessId, Image, FileVersion, Product, Company, OriginalFileName, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, Hashes, ParentProcessGuid, ParentProcessId, ParentImage, ParentCommandLine, TargetFilename, CreationUtcTime, PreviousCreationUtcTime, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, State, Version, SchemaVersion, ImageLoaded, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, EventType, TargetObject, Details, NewName, Hash, Contents, Configuration, ConfigurationFileHash, PipeName, Operation, EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, IsExecutable, Archived, Session, ClientInfo
+SYSMON_ERROR_255, 
+SYSMON_CREATE_PROCESS_1, 
+SYSMON_FILE_TIME_2, 
+SYSMON_NETWORK_CONNECT_3, 
+SYSMON_SERVICE_STATE_CHANGE_4, 
+SYSMON_PROCESS_TERMINATE_5, 
+SYSMON_DRIVER_LOAD_6, 
+SYSMON_IMAGE_LOAD_7, 
+SYSMON_CREATE_REMOTE_THREAD_8, 
+SYSMON_RAWACCESS_READ_9, 
+SYSMON_ACCESS_PROCESS_10, 
+SYSMON_FILE_CREATE_11, 
+SYSMON_REG_KEY_12, 
+SYSMON_REG_SETVALUE_13, 
+SYSMON_REG_NAME_14, 
+SYSMON_FILE_CREATE_STREAM_HASH_15, 
+SYSMON_SERVICE_CONFIGURATION_CHANGE_16, 
+SYSMON_CREATE_NAMEDPIPE_17, 
+SYSMON_CONNECT_NAMEDPIPE_18, 
+SYSMON_WMI_FILTER_19, 
+SYSMON_WMI_CONSUMER_20, 
+SYSMON_WMI_BINDING_21, 
+SYSMON_DNS_QUERY_22, 
+SYSMON_FILE_DELETE_23, 
+SYSMON_CLIPBOARD_24
+)
+| extend Details = column_ifexists("Details", ""), 
+    RuleName = column_ifexists("RuleName", ""),
+    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
+    Hashes = column_ifexists("Hashes", "")
+| project TimeGenerated, 
+Source, 
+Computer, 
+UserName, 
+EventID, 
+UtcTime, 
+ID, 
+Description, 
+RuleName, 
+ProcessGuid, 
+ProcessId, 
+Image, 
+FileVersion, 
+Product, 
+Company, 
+OriginalFileName, 
+CommandLine, 
+CurrentDirectory, 
+User, 
+LogonGuid, 
+LogonId, 
+TerminalSessionId, 
+IntegrityLevel, 
+Hashes, 
+ParentProcessGuid, 
+ParentProcessId, 
+ParentImage, 
+ParentCommandLine, 
+TargetFilename, 
+CreationUtcTime, 
+PreviousCreationUtcTime, 
+Protocol, 
+Initiated, 
+SourceIsIpv6, 
+SourceIp, 
+SourceHostname, 
+SourcePort, 
+SourcePortName, 
+DestinationIsIpv6, 
+DestinationIp, 
+DestinationHostname, 
+DestinationPort, 
+DestinationPortName, 
+State, 
+Version, 
+SchemaVersion, 
+ImageLoaded, 
+Signed, 
+Signature, 
+SignatureStatus, 
+SourceProcessGuid, 
+SourceProcessId, 
+SourceImage, 
+TargetProcessGuid, 
+TargetProcessId, 
+TargetImage, 
+NewThreadId, 
+StartAddress, 
+StartModule, 
+StartFunction, 
+Device, 
+SourceProcessGUID, 
+SourceThreadId, 
+TargetProcessGUID, 
+GrantedAccess, 
+CallTrace, 
+EventType, 
+TargetObject, 
+Details, 
+NewName, 
+Hash, 
+Contents, 
+Configuration, 
+ConfigurationFileHash, 
+PipeName, 
+Operation, 
+EventNamespace, 
+Name, 
+Query, 
+Type, 
+Destination, 
+Consumer, 
+Filter, 
+QueryName, 
+QueryStatus, 
+QueryResults, 
+IsExecutable, 
+Archived, 
+Session, 
+ClientInfo

--- a/resources/parsers/SysmonKQLParserV12.0.txt
+++ b/resources/parsers/SysmonKQLParserV12.0.txt
@@ -307,8 +307,8 @@ ProcessId = EventDetail.[3].["#text"],
 Image = EventDetail.[4].["#text"], 
 TargetFilename = EventDetail.[5].["#text"], 
 CreationUtcTime = EventDetail.[6].["#text"], 
-Hash = EventDetail.[7].["#text"], 
 Contents = EventDetail.[8].["#text"]
+| extend Hash = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hash on (summarize Hash = make_bag(pack(tostring(Hash[0]), tostring(Hash[1]))))
 | project-away EventDetail
 ;
 processEvents;
@@ -489,9 +489,10 @@ SYSMON_FILE_DELETE_23,
 SYSMON_CLIPBOARD_24
 )
 | extend Details = column_ifexists("Details", ""), 
-    RuleName = column_ifexists("RuleName", ""),
-    PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
-    Hashes = column_ifexists("Hashes", "")
+RuleName = column_ifexists("RuleName", ""),
+PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
+Hashes = column_ifexists("Hashes", ""),
+Hash = column_ifexists("Hash", "")
 | project TimeGenerated, 
 Source, 
 Computer, 

--- a/resources/parsers/SysmonKQLParserV13.01.txt
+++ b/resources/parsers/SysmonKQLParserV13.01.txt
@@ -307,8 +307,8 @@ ProcessId = EventDetail.[3].["#text"],
 Image = EventDetail.[4].["#text"], 
 TargetFilename = EventDetail.[5].["#text"], 
 CreationUtcTime = EventDetail.[6].["#text"], 
-Hash = EventDetail.[7].["#text"], 
 Contents = EventDetail.[8].["#text"]
+| extend Hash = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hash on (summarize Hash = make_bag(pack(tostring(Hash[0]), tostring(Hash[1]))))
 | project-away EventDetail
 ;
 processEvents;
@@ -507,7 +507,8 @@ SYSMON_PROCESS_IMAGE_TAMPERING_25
 | extend Details = column_ifexists("Details", ""), 
 RuleName = column_ifexists("RuleName", ""),
 PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
-Hashes = column_ifexists("Hashes", "")
+Hashes = column_ifexists("Hashes", ""),
+Hash = column_ifexists("Hash", "")
 | project TimeGenerated, 
 Source, 
 Computer, 

--- a/resources/parsers/SysmonKQLParserV13.01.txt
+++ b/resources/parsers/SysmonKQLParserV13.01.txt
@@ -1,5 +1,5 @@
 // KQL Sysmon Event Parser
-// Last Updated Date: 2021-01-20
+// Last Updated Date: 2021-02-23
 // Sysmon Version: 13.01, Binary Version : 13.0, Schema Version: 4.50
 //
 // Authors:
@@ -8,220 +8,593 @@
 let EventData = Event
 | where Source == "Microsoft-Windows-Sysmon"
 | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+| project TimeGenerated,
+    Source,
+    EventID,
+    Computer,
+    UserName,
+    EventData,
+    RenderedDescription
 | extend EvData = parse_xml(EventData)
 | extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
-;
+| project-away EventData,
+    EvData;
+// Event ID 255
+//--------------------------
 let SYSMON_ERROR_255=() {
 let processEvents = EventData
 | where EventID == 255
-| extend UtcTime = EventDetail.[0].["#text"], ID = EventDetail.[1].["#text"], Description = EventDetail.[2].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+ID = EventDetail.[1].["#text"], 
+Description = EventDetail.[2].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 1
+//--------------------------
 let SYSMON_CREATE_PROCESS_1=() {
 let processEvents = EventData
 | where EventID == 1
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], FileVersion = EventDetail.[5].["#text"], Description = EventDetail.[6].["#text"], Product = EventDetail.[7].["#text"], Company = EventDetail.[8].["#text"], OriginalFileName = EventDetail.[9].["#text"], CommandLine = EventDetail.[10].["#text"], CurrentDirectory = EventDetail.[11].["#text"], User = EventDetail.[12].["#text"], LogonGuid = EventDetail.[13].["#text"], LogonId = EventDetail.[14].["#text"], TerminalSessionId = EventDetail.[15].["#text"], IntegrityLevel = EventDetail.[16].["#text"], Hashes = EventDetail.[17].["#text"], ParentProcessGuid = EventDetail.[18].["#text"], ParentProcessId = EventDetail.[19].["#text"], ParentImage = EventDetail.[20].["#text"], ParentCommandLine = EventDetail.[21].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+FileVersion = EventDetail.[5].["#text"], 
+Description = EventDetail.[6].["#text"], 
+Product = EventDetail.[7].["#text"], 
+Company = EventDetail.[8].["#text"], 
+OriginalFileName = EventDetail.[9].["#text"], 
+CommandLine = EventDetail.[10].["#text"], 
+CurrentDirectory = EventDetail.[11].["#text"], 
+User = EventDetail.[12].["#text"], 
+LogonGuid = EventDetail.[13].["#text"], 
+LogonId = EventDetail.[14].["#text"], 
+TerminalSessionId = EventDetail.[15].["#text"], 
+IntegrityLevel = EventDetail.[16].["#text"], 
+ParentProcessGuid = EventDetail.[18].["#text"], 
+ParentProcessId = EventDetail.[19].["#text"], 
+ParentImage = EventDetail.[20].["#text"], 
+ParentCommandLine = EventDetail.[21].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[17].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 2
+//--------------------------
 let SYSMON_FILE_TIME_2=() {
 let processEvents = EventData
 | where EventID == 2
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], PreviousCreationUtcTime = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"], 
+PreviousCreationUtcTime = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 3
+//--------------------------
 let SYSMON_NETWORK_CONNECT_3=() {
 let processEvents = EventData
 | where EventID == 3
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], User = EventDetail.[5].["#text"], Protocol = EventDetail.[6].["#text"], Initiated = EventDetail.[7].["#text"], SourceIsIpv6 = EventDetail.[8].["#text"], SourceIp = EventDetail.[9].["#text"], SourceHostname = EventDetail.[10].["#text"], SourcePort = EventDetail.[11].["#text"], SourcePortName = EventDetail.[12].["#text"], DestinationIsIpv6 = EventDetail.[13].["#text"], DestinationIp = EventDetail.[14].["#text"], DestinationHostname = EventDetail.[15].["#text"], DestinationPort = EventDetail.[16].["#text"], DestinationPortName = EventDetail.[17].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+User = EventDetail.[5].["#text"], 
+Protocol = EventDetail.[6].["#text"], 
+Initiated = EventDetail.[7].["#text"], 
+SourceIsIpv6 = EventDetail.[8].["#text"], 
+SourceIp = EventDetail.[9].["#text"], 
+SourceHostname = EventDetail.[10].["#text"], 
+SourcePort = EventDetail.[11].["#text"], 
+SourcePortName = EventDetail.[12].["#text"], 
+DestinationIsIpv6 = EventDetail.[13].["#text"], 
+DestinationIp = EventDetail.[14].["#text"], 
+DestinationHostname = EventDetail.[15].["#text"], 
+DestinationPort = EventDetail.[16].["#text"], 
+DestinationPortName = EventDetail.[17].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 4
+//--------------------------
 let SYSMON_SERVICE_STATE_CHANGE_4=() {
 let processEvents = EventData
 | where EventID == 4
-| extend UtcTime = EventDetail.[0].["#text"], State = EventDetail.[1].["#text"], Version = EventDetail.[2].["#text"], SchemaVersion = EventDetail.[3].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+State = EventDetail.[1].["#text"], 
+Version = EventDetail.[2].["#text"], 
+SchemaVersion = EventDetail.[3].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 5
+//--------------------------
 let SYSMON_PROCESS_TERMINATE_5=() {
 let processEvents = EventData
 | where EventID == 5
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 6
+//--------------------------
 let SYSMON_DRIVER_LOAD_6=() {
 let processEvents = EventData
 | where EventID == 6
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ImageLoaded = EventDetail.[2].["#text"], Hashes = EventDetail.[3].["#text"], Signed = EventDetail.[4].["#text"], Signature = EventDetail.[5].["#text"], SignatureStatus = EventDetail.[6].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ImageLoaded = EventDetail.[2].["#text"], 
+Signed = EventDetail.[4].["#text"], 
+Signature = EventDetail.[5].["#text"], 
+SignatureStatus = EventDetail.[6].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[3].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 7
+//--------------------------
 let SYSMON_IMAGE_LOAD_7=() {
 let processEvents = EventData
 | where EventID == 7
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], ImageLoaded = EventDetail.[5].["#text"], FileVersion = EventDetail.[6].["#text"], Description = EventDetail.[7].["#text"], Product = EventDetail.[8].["#text"], Company = EventDetail.[9].["#text"], OriginalFileName = EventDetail.[10].["#text"], Hashes = EventDetail.[11].["#text"], Signed = EventDetail.[12].["#text"], Signature = EventDetail.[13].["#text"], SignatureStatus = EventDetail.[14].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+ImageLoaded = EventDetail.[5].["#text"], 
+FileVersion = EventDetail.[6].["#text"], 
+Description = EventDetail.[7].["#text"], 
+Product = EventDetail.[8].["#text"], 
+Company = EventDetail.[9].["#text"], 
+OriginalFileName = EventDetail.[10].["#text"], 
+Signed = EventDetail.[12].["#text"], 
+Signature = EventDetail.[13].["#text"], 
+SignatureStatus = EventDetail.[14].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[11].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 8
+//--------------------------
 let SYSMON_CREATE_REMOTE_THREAD_8=() {
 let processEvents = EventData
 | where EventID == 8
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGuid = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], SourceImage = EventDetail.[4].["#text"], TargetProcessGuid = EventDetail.[5].["#text"], TargetProcessId = EventDetail.[6].["#text"], TargetImage = EventDetail.[7].["#text"], NewThreadId = EventDetail.[8].["#text"], StartAddress = EventDetail.[9].["#text"], StartModule = EventDetail.[10].["#text"], StartFunction = EventDetail.[11].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+SourceProcessGuid = EventDetail.[2].["#text"], 
+SourceProcessId = EventDetail.[3].["#text"], 
+SourceImage = EventDetail.[4].["#text"], 
+TargetProcessGuid = EventDetail.[5].["#text"], 
+TargetProcessId = EventDetail.[6].["#text"], 
+TargetImage = EventDetail.[7].["#text"], 
+NewThreadId = EventDetail.[8].["#text"], 
+StartAddress = EventDetail.[9].["#text"], 
+StartModule = EventDetail.[10].["#text"], 
+StartFunction = EventDetail.[11].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 9
+//--------------------------
 let SYSMON_RAWACCESS_READ_9=() {
 let processEvents = EventData
 | where EventID == 9
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Device = EventDetail.[5].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+Device = EventDetail.[5].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 10
+//--------------------------
 let SYSMON_ACCESS_PROCESS_10=() {
 let processEvents = EventData
 | where EventID == 10
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], SourceProcessGUID = EventDetail.[2].["#text"], SourceProcessId = EventDetail.[3].["#text"], SourceThreadId = EventDetail.[4].["#text"], SourceImage = EventDetail.[5].["#text"], TargetProcessGUID = EventDetail.[6].["#text"], TargetProcessId = EventDetail.[7].["#text"], TargetImage = EventDetail.[8].["#text"], GrantedAccess = EventDetail.[9].["#text"], CallTrace = EventDetail.[10].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+SourceProcessGUID = EventDetail.[2].["#text"], 
+SourceProcessId = EventDetail.[3].["#text"], 
+SourceThreadId = EventDetail.[4].["#text"], 
+SourceImage = EventDetail.[5].["#text"], 
+TargetProcessGUID = EventDetail.[6].["#text"], 
+TargetProcessId = EventDetail.[7].["#text"], 
+TargetImage = EventDetail.[8].["#text"], 
+GrantedAccess = EventDetail.[9].["#text"], 
+CallTrace = EventDetail.[10].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 11
+//--------------------------
 let SYSMON_FILE_CREATE_11=() {
 let processEvents = EventData
 | where EventID == 11
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 12
+//--------------------------
 let SYSMON_REG_KEY_12=() {
 let processEvents = EventData
 | where EventID == 12
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 13
+//--------------------------
 let SYSMON_REG_SETVALUE_13=() {
 let processEvents = EventData
 | where EventID == 13
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], Details = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"], 
+Details = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 14
+//--------------------------
 let SYSMON_REG_NAME_14=() {
 let processEvents = EventData
 | where EventID == 14
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetObject = EventDetail.[6].["#text"], NewName = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetObject = EventDetail.[6].["#text"], 
+NewName = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 15
+//--------------------------
 let SYSMON_FILE_CREATE_STREAM_HASH_15=() {
 let processEvents = EventData
 | where EventID == 15
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], TargetFilename = EventDetail.[5].["#text"], CreationUtcTime = EventDetail.[6].["#text"], Hash = EventDetail.[7].["#text"], Contents = EventDetail.[8].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+TargetFilename = EventDetail.[5].["#text"], 
+CreationUtcTime = EventDetail.[6].["#text"], 
+Hash = EventDetail.[7].["#text"], 
+Contents = EventDetail.[8].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 16
+//--------------------------
 let SYSMON_SERVICE_CONFIGURATION_CHANGE_16=() {
 let processEvents = EventData
 | where EventID == 16
-| extend UtcTime = EventDetail.[0].["#text"], Configuration = EventDetail.[1].["#text"], ConfigurationFileHash = EventDetail.[2].["#text"]
+| extend UtcTime = EventDetail.[0].["#text"], 
+Configuration = EventDetail.[1].["#text"], 
+ConfigurationFileHash = EventDetail.[2].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 17
+//--------------------------
 let SYSMON_CREATE_NAMEDPIPE_17=() {
 let processEvents = EventData
 | where EventID == 17
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+PipeName = EventDetail.[5].["#text"], 
+Image = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 18
+//--------------------------
 let SYSMON_CONNECT_NAMEDPIPE_18=() {
 let processEvents = EventData
 | where EventID == 18
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], ProcessGuid = EventDetail.[3].["#text"], ProcessId = EventDetail.[4].["#text"], PipeName = EventDetail.[5].["#text"], Image = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+ProcessGuid = EventDetail.[3].["#text"], 
+ProcessId = EventDetail.[4].["#text"], 
+PipeName = EventDetail.[5].["#text"], 
+Image = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 19
+//--------------------------
 let SYSMON_WMI_FILTER_19=() {
 let processEvents = EventData
 | where EventID == 19
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], EventNamespace = EventDetail.[5].["#text"], Name = EventDetail.[6].["#text"], Query = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+EventNamespace = EventDetail.[5].["#text"], 
+Name = EventDetail.[6].["#text"], 
+Query = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 20
+//--------------------------
 let SYSMON_WMI_CONSUMER_20=() {
 let processEvents = EventData
 | where EventID == 20
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Name = EventDetail.[5].["#text"], Type = EventDetail.[6].["#text"], Destination = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Name = EventDetail.[5].["#text"], 
+Type = EventDetail.[6].["#text"], 
+Destination = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 21
+//--------------------------
 let SYSMON_WMI_BINDING_21=() {
 let processEvents = EventData
 | where EventID == 21
-| extend RuleName = EventDetail.[0].["#text"], EventType = EventDetail.[1].["#text"], UtcTime = EventDetail.[2].["#text"], Operation = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Consumer = EventDetail.[5].["#text"], Filter = EventDetail.[6].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+EventType = EventDetail.[1].["#text"], 
+UtcTime = EventDetail.[2].["#text"], 
+Operation = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Consumer = EventDetail.[5].["#text"], 
+Filter = EventDetail.[6].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 22
+//--------------------------
 let SYSMON_DNS_QUERY_22=() {
 let processEvents = EventData
 | where EventID == 22
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], QueryName = EventDetail.[4].["#text"], QueryStatus = EventDetail.[5].["#text"], QueryResults = EventDetail.[6].["#text"], Image = EventDetail.[7].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+QueryName = EventDetail.[4].["#text"], 
+QueryStatus = EventDetail.[5].["#text"], 
+QueryResults = EventDetail.[6].["#text"], 
+Image = EventDetail.[7].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 23
+//--------------------------
 let SYSMON_FILE_DELETE_23=() {
 let processEvents = EventData
 | where EventID == 23
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], User = EventDetail.[4].["#text"], Image = EventDetail.[5].["#text"], TargetFilename = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], IsExecutable = EventDetail.[8].["#text"], Archived = EventDetail.[9].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+User = EventDetail.[4].["#text"], 
+Image = EventDetail.[5].["#text"], 
+TargetFilename = EventDetail.[6].["#text"], 
+IsExecutable = EventDetail.[8].["#text"], 
+Archived = EventDetail.[9].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 24
+//--------------------------
 let SYSMON_CLIPBOARD_24=() {
 let processEvents = EventData
 | where EventID == 24
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Session = EventDetail.[5].["#text"], ClientInfo = EventDetail.[6].["#text"], Hashes = EventDetail.[7].["#text"], Archived = EventDetail.[8].["#text"]
-| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH| project-away EventDetail
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+Session = EventDetail.[5].["#text"], 
+ClientInfo = EventDetail.[6].["#text"], 
+Archived = EventDetail.[8].["#text"]
+| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[7].["#text"]))| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1]))))
+| project-away EventDetail
 ;
 processEvents;
 };
+// Event ID 25
+//--------------------------
 let SYSMON_PROCESS_IMAGE_TAMPERING_25=() {
 let processEvents = EventData
 | where EventID == 25
-| extend RuleName = EventDetail.[0].["#text"], UtcTime = EventDetail.[1].["#text"], ProcessGuid = EventDetail.[2].["#text"], ProcessId = EventDetail.[3].["#text"], Image = EventDetail.[4].["#text"], Type = EventDetail.[5].["#text"]
+| extend RuleName = EventDetail.[0].["#text"], 
+UtcTime = EventDetail.[1].["#text"], 
+ProcessGuid = EventDetail.[2].["#text"], 
+ProcessId = EventDetail.[3].["#text"], 
+Image = EventDetail.[4].["#text"], 
+Type = EventDetail.[5].["#text"]
 | project-away EventDetail
 ;
 processEvents;
 };
 (union isfuzzy=true
-SYSMON_ERROR_255, SYSMON_CREATE_PROCESS_1, SYSMON_FILE_TIME_2, SYSMON_NETWORK_CONNECT_3, SYSMON_SERVICE_STATE_CHANGE_4, SYSMON_PROCESS_TERMINATE_5, SYSMON_DRIVER_LOAD_6, SYSMON_IMAGE_LOAD_7, SYSMON_CREATE_REMOTE_THREAD_8, SYSMON_RAWACCESS_READ_9, SYSMON_ACCESS_PROCESS_10, SYSMON_FILE_CREATE_11, SYSMON_REG_KEY_12, SYSMON_REG_SETVALUE_13, SYSMON_REG_NAME_14, SYSMON_FILE_CREATE_STREAM_HASH_15, SYSMON_SERVICE_CONFIGURATION_CHANGE_16, SYSMON_CREATE_NAMEDPIPE_17, SYSMON_CONNECT_NAMEDPIPE_18, SYSMON_WMI_FILTER_19, SYSMON_WMI_CONSUMER_20, SYSMON_WMI_BINDING_21, SYSMON_DNS_QUERY_22, SYSMON_FILE_DELETE_23, SYSMON_CLIPBOARD_24, SYSMON_PROCESS_IMAGE_TAMPERING_25)
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", "")
-| project EventID, UtcTime, ID, Description, RuleName, ProcessGuid, ProcessId, Image, FileVersion, Product, Company, OriginalFileName, CommandLine, CurrentDirectory, User, LogonGuid, LogonId, TerminalSessionId, IntegrityLevel, Hashes, ParentProcessGuid, ParentProcessId, ParentImage, ParentCommandLine, TargetFilename, CreationUtcTime, PreviousCreationUtcTime, Protocol, Initiated, SourceIsIpv6, SourceIp, SourceHostname, SourcePort, SourcePortName, DestinationIsIpv6, DestinationIp, DestinationHostname, DestinationPort, DestinationPortName, State, Version, SchemaVersion, ImageLoaded, Signed, Signature, SignatureStatus, SourceProcessGuid, SourceProcessId, SourceImage, TargetProcessGuid, TargetProcessId, TargetImage, NewThreadId, StartAddress, StartModule, StartFunction, Device, SourceProcessGUID, SourceThreadId, TargetProcessGUID, GrantedAccess, CallTrace, EventType, TargetObject, Details, NewName, Hash, Contents, Configuration, ConfigurationFileHash, PipeName, Operation, EventNamespace, Name, Query, Type, Destination, Consumer, Filter, QueryName, QueryStatus, QueryResults, IsExecutable, Archived, Session, ClientInfo
+SYSMON_ERROR_255, 
+SYSMON_CREATE_PROCESS_1, 
+SYSMON_FILE_TIME_2, 
+SYSMON_NETWORK_CONNECT_3, 
+SYSMON_SERVICE_STATE_CHANGE_4, 
+SYSMON_PROCESS_TERMINATE_5, 
+SYSMON_DRIVER_LOAD_6, 
+SYSMON_IMAGE_LOAD_7, 
+SYSMON_CREATE_REMOTE_THREAD_8, 
+SYSMON_RAWACCESS_READ_9, 
+SYSMON_ACCESS_PROCESS_10, 
+SYSMON_FILE_CREATE_11, 
+SYSMON_REG_KEY_12, 
+SYSMON_REG_SETVALUE_13, 
+SYSMON_REG_NAME_14, 
+SYSMON_FILE_CREATE_STREAM_HASH_15, 
+SYSMON_SERVICE_CONFIGURATION_CHANGE_16, 
+SYSMON_CREATE_NAMEDPIPE_17, 
+SYSMON_CONNECT_NAMEDPIPE_18, 
+SYSMON_WMI_FILTER_19, 
+SYSMON_WMI_CONSUMER_20, 
+SYSMON_WMI_BINDING_21, 
+SYSMON_DNS_QUERY_22, 
+SYSMON_FILE_DELETE_23, 
+SYSMON_CLIPBOARD_24, 
+SYSMON_PROCESS_IMAGE_TAMPERING_25
+)
+| extend Details = column_ifexists("Details", ""), 
+RuleName = column_ifexists("RuleName", ""),
+PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
+Hashes = column_ifexists("Hashes", "")
+| project TimeGenerated, 
+Source, 
+Computer, 
+UserName, 
+EventID, 
+UtcTime, 
+ID, 
+Description, 
+RuleName, 
+ProcessGuid, 
+ProcessId, 
+Image, 
+FileVersion, 
+Product, 
+Company, 
+OriginalFileName, 
+CommandLine, 
+CurrentDirectory, 
+User, 
+LogonGuid, 
+LogonId, 
+TerminalSessionId, 
+IntegrityLevel, 
+Hashes, 
+ParentProcessGuid, 
+ParentProcessId, 
+ParentImage, 
+ParentCommandLine, 
+TargetFilename, 
+CreationUtcTime, 
+PreviousCreationUtcTime, 
+Protocol, 
+Initiated, 
+SourceIsIpv6, 
+SourceIp, 
+SourceHostname, 
+SourcePort, 
+SourcePortName, 
+DestinationIsIpv6, 
+DestinationIp, 
+DestinationHostname, 
+DestinationPort, 
+DestinationPortName, 
+State, 
+Version, 
+SchemaVersion, 
+ImageLoaded, 
+Signed, 
+Signature, 
+SignatureStatus, 
+SourceProcessGuid, 
+SourceProcessId, 
+SourceImage, 
+TargetProcessGuid, 
+TargetProcessId, 
+TargetImage, 
+NewThreadId, 
+StartAddress, 
+StartModule, 
+StartFunction, 
+Device, 
+SourceProcessGUID, 
+SourceThreadId, 
+TargetProcessGUID, 
+GrantedAccess, 
+CallTrace, 
+EventType, 
+TargetObject, 
+Details, 
+NewName, 
+Hash, 
+Contents, 
+Configuration, 
+ConfigurationFileHash, 
+PipeName, 
+Operation, 
+EventNamespace, 
+Name, 
+Query, 
+Type, 
+Destination, 
+Consumer, 
+Filter, 
+QueryName, 
+QueryStatus, 
+QueryResults, 
+IsExecutable, 
+Archived, 
+Session, 
+ClientInfo

--- a/resources/tools/ossemSysmonKQLParser.py
+++ b/resources/tools/ossemSysmonKQLParser.py
@@ -90,7 +90,7 @@ for item in eventlist:
 
 # ******** Unique List of Events ****************
 log.info('Creating a list of all unique field names')
-unique_fields = ['EventID']
+unique_fields = ['TimeGenerated','Source','Computer','UserName','EventID']
 for sysevent in all_sysmon:
     for field in sysevent['events']:
         if field['name'] not in unique_fields:

--- a/resources/tools/templates/kql/sysmon_parser.txt
+++ b/resources/tools/templates/kql/sysmon_parser.txt
@@ -8,22 +8,42 @@
 let EventData = Event
 | where Source == "Microsoft-Windows-Sysmon"
 | extend RenderedDescription = tostring(split(RenderedDescription, ":")[0])
-| project TimeGenerated, Source, EventID, Computer, UserName, EventData, RenderedDescription
+| project TimeGenerated,
+    Source,
+    EventID,
+    Computer,
+    UserName,
+    EventData,
+    RenderedDescription
 | extend EvData = parse_xml(EventData)
 | extend EventDetail = EvData.DataItem.EventData.Data
-| project-away EventData, EvData
-;{% endraw %}
-{% for event in sysmon %}let {{event['name']}}_{{event['id']}}{% raw %}=() {
+| project-away EventData,
+    EvData;{% endraw %}
+{% for event in sysmon %}// Event ID {{event['id']}}
+//--------------------------
+let {{event['name']}}_{{event['id']}}{% raw %}=() {
 let processEvents = EventData
 | where EventID == {% endraw %}{{event['id']}}
-| extend {% for field in event['events'] %}{{field['name']}}{% raw %} = EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]{% endraw %}{{ ", " if not loop.last else "" }}{% endfor %}
-{% for e in event['events'] %}{% for k,v in e.items() %}{% if v == 'Hashes' %}{% raw %}| parse Hashes with * 'SHA1=' SHA1 ',' * 'MD5=' MD5 ',' * 'SHA256=' SHA256 ',' * 'IMPHASH=' IMPHASH{% endraw %}{% endif %}{%- endfor -%}{%- endfor -%}{% raw %}| project-away EventDetail
+| extend {% for field in event['events'] if field['name'] != 'Hashes' %}{{field['name']}}{% raw %} = EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]{% endraw %}{{ ", " if not loop.last else "" }}
+{% endfor -%}
+{% for field in event['events'] -%}
+    {% if field['name'] == 'Hashes' -%}
+        {%- raw %}| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"])){% endraw %}
+        {%- raw %}| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))){% endraw %}
+{% endif %}{% endfor %}
+{%- raw %}| project-away EventDetail
 ;
 processEvents;
 };
 {% endraw %}
 {%- endfor -%}
 {% raw %}(union isfuzzy=true{% endraw %}
-{% for event in sysmon %}{{event['name']}}_{{event['id']}}{{ ", " if not loop.last else "" }}{% endfor %}){% raw %}
-| extend Details = column_ifexists("Details", ""), RuleName = column_ifexists("RuleName", ""), PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""){% endraw %}
-{%raw%}| project {% endraw %}{% for uniqueevent in uniquesysmon %}{{ uniqueevent }}{{ ", " if not loop.last else "" }}{% endfor %}
+{% for event in sysmon -%}
+    {{event['name']}}_{{event['id']}}{{ ", " if not loop.last else "" }}
+{% endfor -%}){% raw %}
+| extend Details = column_ifexists("Details", ""), 
+RuleName = column_ifexists("RuleName", ""),
+PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
+Hashes = column_ifexists("Hashes", ""){% endraw %}
+{%raw%}| project {% endraw %}{% for uniqueevent in uniquesysmon %}{{ uniqueevent }}{{ ", " if not loop.last else "" }}
+{% endfor -%}

--- a/resources/tools/templates/kql/sysmon_parser.txt
+++ b/resources/tools/templates/kql/sysmon_parser.txt
@@ -24,12 +24,12 @@ let EventData = Event
 let {{event['name']}}_{{event['id']}}{% raw %}=() {
 let processEvents = EventData
 | where EventID == {% endraw %}{{event['id']}}
-| extend {% for field in event['events'] if field['name'] != 'Hashes' %}{{field['name']}}{% raw %} = EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]{% endraw %}{{ ", " if not loop.last else "" }}
+| extend {% for field in event['events'] if field['name'] not in ['Hashes','Hash'] %}{{field['name']}}{% raw %} = EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]{% endraw %}{{ ", " if not loop.last else "" }}
 {% endfor -%}
 {% for field in event['events'] -%}
-    {% if field['name'] == 'Hashes' -%}
-        {%- raw %}| extend Hashes = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"])){% endraw %}
-        {%- raw %}| mv-apply Hashes on (summarize Hashes = make_bag(pack(tostring(Hashes[0]), tostring(Hashes[1])))){% endraw %}
+    {% if field['name'] in ['Hashes','Hash'] -%}
+        {%- raw %}| extend {% endraw %}{{field['name']}}{% raw %} = extract_all(@"(?P<key>\w+)=(?P<value>[a-zA-Z0-9]+)", dynamic(["key","value"]), tostring(EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"])){% endraw %}
+        {%- raw %}| mv-apply {% endraw %}{{field['name']}}{% raw %} on (summarize {% endraw %}{{field['name']}}{% raw %} = make_bag(pack(tostring({% endraw %}{{field['name']}}{% raw %}[0]), tostring({% endraw %}{{field['name']}}{% raw %}[1])))){% endraw %}
 {% endif %}{% endfor %}
 {%- raw %}| project-away EventDetail
 ;
@@ -44,6 +44,7 @@ processEvents;
 | extend Details = column_ifexists("Details", ""), 
 RuleName = column_ifexists("RuleName", ""),
 PreviousCreationUtcTime=column_ifexists("PreviousCreationUtcTime", ""),
-Hashes = column_ifexists("Hashes", ""){% endraw %}
+Hashes = column_ifexists("Hashes", ""),
+Hash = column_ifexists("Hash", ""){% endraw %}
 {%raw%}| project {% endraw %}{% for uniqueevent in uniquesysmon %}{{ uniqueevent }}{{ ", " if not loop.last else "" }}
 {% endfor -%}


### PR DESCRIPTION
## References
https://github.com/OTRF/OSSEM/issues/99
https://github.com/Azure/Azure-Sentinel/pull/1754

## Added Original Protected Fields

![image](https://user-images.githubusercontent.com/9653181/108921024-ba72d780-7603-11eb-8c5a-4225415037be.png)


## Expanded Fields to show one per line making it easier to follow and troubleshoot and improved Hashes handling

![image](https://user-images.githubusercontent.com/9653181/108921159-ec843980-7603-11eb-803c-753aab34a384.png)

## Added support to also handle Sysmon Event ID 15 (`FileCreateStreamHash`). It has a field named `Hash`. Jinja template and KQL parser in OSSEM now also handles the `Hash` field name. Same logic as `Hashes` field.

```
<event name="SYSMON_FILE_CREATE_STREAM_HASH" value="15" level="Informational" template="File stream created" rulename="FileCreateStreamHash" ruledefault="exclude" version="2">
      <data name="RuleName" inType="win:UnicodeString" outType="xs:string" />
      <data name="UtcTime" inType="win:UnicodeString" outType="xs:string" />
      <data name="ProcessGuid" inType="win:GUID" />
      <data name="ProcessId" inType="win:UInt32" outType="win:PID" />
      <data name="Image" inType="win:UnicodeString" outType="xs:string" />
      <data name="TargetFilename" inType="win:UnicodeString" outType="xs:string" />
      <data name="CreationUtcTime" inType="win:UnicodeString" outType="xs:string" />
      <data name="Hash" inType="win:UnicodeString" outType="xs:string" />
      <data name="Contents" inType="win:UnicodeString" outType="xs:string" />
    </event>
```

![image](https://user-images.githubusercontent.com/9653181/108921469-674d5480-7604-11eb-8d79-85c1082cc158.png)

