### PR TITLE
Make Sysmon data dictionaries entities-compliant

### DIFF
--- a/data_dictionaries/windows/sysmon/events/event-1.md
+++ b/data_dictionaries/windows/sysmon/events/event-1.md
@@ -8,17 +8,17 @@ The **process creation** event provides extended information about a newly creat
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that got spawned/created (child)|`{A98268C1-9C2E-5ACD-0000-0010396CAB00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the created process (child)|`4756`|
-|process_path|Image|string|File path of the process being spawned/created. Considered also the child or source process|`C:\Windows\System32\conhost.exe`|
+|process_file_path|Image|string|File path of the process being spawned/created. Considered also the child or source process|`C:\Windows\System32\conhost.exe`|
 |file_version|FileVersion|string|Version of the image associated with the main process (child)|`10.0.16299.15 (WinBuild.160101.0800)`|
 |file_description|Description|string|Description of the image associated with the main process (child)|`Console Window Host`|
 |file_product|Product|string|Product name the image associated with the main process (child) belongs to|`Microsoft® Windows® Operating System`|
 |file_company|Company|string|Company name the image associated with the main process (child) belongs to|`Microsoft Corporation`|
 |file_name_original|OriginalFileName|string|original file name|`wuauclt.exe`|
 |process_command_line|CommandLine|string|Arguments which were passed to the executable associated with the main process|`??\C:\WINDOWS\system32\conhost.exe 0xffffffff -ForceV1`|
-|file_current_directory|CurrentDirectory|string|The path without the name of the image associated with the process|`C:\WINDOWS`|
+|process_file_directory|CurrentDirectory|string|The path without the name of the image associated with the process|`C:\WINDOWS`|
 |user_name|User|string|Name of the account who created the process (child) . It usually contains domain name and user name (Parsed to show only username without the domain)|`DESKTOP-WARDOG\wardog`|
 |user_logon_guid|LogonGuid|string|Logon GUID of the user who created the new process. Value that can help you correlate this event with others that contain the same Logon GUID (Sysmon Events)|`{A98268C1-95F2-5ACD-0000-002019620F00}`|
 |user_logon_id|LogonId|integer|Login ID of the user who created the new process. Value that can help you correlate this event with others that contain the same Logon ID|`0xf6219`|
@@ -27,7 +27,7 @@ The **process creation** event provides extended information about a newly creat
 |TBD|Hashes|string|Hashes captured by sysmon driver|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|
 |process_parent_guid|ParentProcessGuid|string|ProcessGUID of the process that spawned/created the main process (child)|`{A98268C1-9C2E-5ACD-0000-00100266AB00}`|
 |process_parent_id|ParentProcessId|integer|Process ID of the process that spawned/created the main process (child)|`240`|
-|process_parent_path|ParentImage|string|File path that spawned/created the main process|`C:\Windows\System32\cmd.exe`|
+|process_parent_file_path|ParentImage|string|File path that spawned/created the main process|`C:\Windows\System32\cmd.exe`|
 |process_parent_command_line|ParentCommandLine|string|Arguments which were passed to the executable associated with the parent process|`C:\WINDOWS\system32\cmd.exe`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-1.md
+++ b/data_dictionaries/windows/sysmon/events/event-1.md
@@ -12,11 +12,11 @@ The **process creation** event provides extended information about a newly creat
 |process_guid|ProcessGuid|string|Process Guid of the process that got spawned/created (child)|`{A98268C1-9C2E-5ACD-0000-0010396CAB00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the created process (child)|`4756`|
 |process_file_path|Image|string|File path of the process being spawned/created. Considered also the child or source process|`C:\Windows\System32\conhost.exe`|
-|file_version|FileVersion|string|Version of the image associated with the main process (child)|`10.0.16299.15 (WinBuild.160101.0800)`|
-|file_description|Description|string|Description of the image associated with the main process (child)|`Console Window Host`|
-|file_product|Product|string|Product name the image associated with the main process (child) belongs to|`Microsoft® Windows® Operating System`|
-|file_company|Company|string|Company name the image associated with the main process (child) belongs to|`Microsoft Corporation`|
-|file_name_original|OriginalFileName|string|original file name|`wuauclt.exe`|
+|process_file_version|FileVersion|string|Version of the image associated with the main process (child)|`10.0.16299.15 (WinBuild.160101.0800)`|
+|process_file_description|Description|string|Description of the image associated with the main process (child)|`Console Window Host`|
+|process_file_product|Product|string|Product name the image associated with the main process (child) belongs to|`Microsoft® Windows® Operating System`|
+|process_file_company|Company|string|Company name the image associated with the main process (child) belongs to|`Microsoft Corporation`|
+|process_file_name_original|OriginalFileName|string|original file name|`wuauclt.exe`|
 |process_command_line|CommandLine|string|Arguments which were passed to the executable associated with the main process|`??\C:\WINDOWS\system32\conhost.exe 0xffffffff -ForceV1`|
 |process_file_directory|CurrentDirectory|string|The path without the name of the image associated with the process|`C:\WINDOWS`|
 |user_name|User|string|Name of the account who created the process (child) . It usually contains domain name and user name (Parsed to show only username without the domain)|`DESKTOP-WARDOG\wardog`|

--- a/data_dictionaries/windows/sysmon/events/event-10.md
+++ b/data_dictionaries/windows/sysmon/events/event-10.md
@@ -8,14 +8,14 @@ The **process accessed** event reports when a process opens another process, an 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:18`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:18`|
 |process_guid|SourceProcessGuid|string|Process Guid of the source process that opened another process. It is derived from a truncated part of the machine GUID, the process start-time and the process token ID.|`{A98268C1-9587-5ACD-0000-001004C40000}`|
 |process_id|SourceProcessId|integer|Process ID used by the os to identify the source process that opened another process. Derived partially from the EPROCESS kernel structure|`916`|
 |thread_id|SourceThreadId|integer|ID of the specific thread inside of the source process that opened another process|`2804`|
-|process_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\WINDOWS\system32\svchost.exe`|
+|process_file_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\WINDOWS\system32\svchost.exe`|
 |target_process_guid|TargetProcessGuid|string|Process Guid of the target process|`{A98268C1-9597-5ACD-0000-00101D690200}`|
 |target_process_id|TargetProcessId|integer|Process ID used by the os to identify the target process|`2288`|
-|target_process_path|TargetImage|string|File path of the target process|`C:\ProgramData\Microsoft\Windows Defender\platform\4.12.17007.18022-0\MsMpEng.exe`|
+|target_process_file_path|TargetImage|string|File path of the target process|`C:\ProgramData\Microsoft\Windows Defender\platform\4.12.17007.18022-0\MsMpEng.exe`|
 |process_granted_access|GrantedAccess|string|The access flags (bitmask) associated with the process rights requested for the target process|`0x1000`|
 |process_call_trace|CallTrace|string|Stack trace of where open process is called. Included is the DLL and the relative virtual address of the functions in the call stack right before the open process call|`C:\WINDOWS\SYSTEM32\ntdll.dll+a0344`|
 

--- a/data_dictionaries/windows/sysmon/events/event-11.md
+++ b/data_dictionaries/windows/sysmon/events/event-11.md
@@ -12,7 +12,7 @@
 |process_guid|ProcessGuid|string|Process Guid of the process that created the file|`{A98268C1-958A-5ACD-0000-0010C62F0100}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the file (child)|`1044`|
 |process_file_path|Image|string|File path of the process that created the file|`C:\WINDOWS\System32\svchost.exe`|
-|file_name|TargetFilename|string|Name of the file|`C:\Windows\Prefetch\CONHOST.EXE-1F3E9D7E.pf`|
+|file_path|TargetFilename|string|Name of the file|`C:\Windows\Prefetch\CONHOST.EXE-1F3E9D7E.pf`|
 |file_creation_time|CreationUtcTime|date|File creation time|`12/4/17 17:38`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-11.md
+++ b/data_dictionaries/windows/sysmon/events/event-11.md
@@ -8,12 +8,12 @@
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:01`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:01`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the file|`{A98268C1-958A-5ACD-0000-0010C62F0100}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the file (child)|`1044`|
-|process_path|Image|string|File path of the process that created the file|`C:\WINDOWS\System32\svchost.exe`|
+|process_file_path|Image|string|File path of the process that created the file|`C:\WINDOWS\System32\svchost.exe`|
 |file_name|TargetFilename|string|Name of the file|`C:\Windows\Prefetch\CONHOST.EXE-1F3E9D7E.pf`|
-|file_date_creation|CreationUtcTime|date|File creation time|`12/4/17 17:38`|
+|file_creation_time|CreationUtcTime|date|File creation time|`12/4/17 17:38`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-11-filecreate)

--- a/data_dictionaries/windows/sysmon/events/event-12.md
+++ b/data_dictionaries/windows/sysmon/events/event-12.md
@@ -9,11 +9,11 @@
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|registry event. Either Create or Delete|`CreateKey`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created or deleted a registry key|`{A98268C1-9595-5ACD-0000-0010C2380200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created or deleted a registry key|`2052`|
-|process_path|Image|string|File path of the process that created or deleted a registry key|`C:\Program Files\Common Files\Microsoft Shared\ClickToRun\OfficeClickToRun.exe`|
-|registry_key_path|TargetObject|string|complete path of the registry key|`HKU.DEFAULT\Software\Microsoft\Office\16.0\Common`|
+|process_file_path|Image|string|File path of the process that created or deleted a registry key|`C:\Program Files\Common Files\Microsoft Shared\ClickToRun\OfficeClickToRun.exe`|
+|registry_path|TargetObject|string|complete path of the registry key|`HKU.DEFAULT\Software\Microsoft\Office\16.0\Common`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-12-registryevent-object-create-and-delete)

--- a/data_dictionaries/windows/sysmon/events/event-13.md
+++ b/data_dictionaries/windows/sysmon/events/event-13.md
@@ -9,12 +9,12 @@ This Registry event type identifies **Registry value modifications**. The event 
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|registry event. Registry values modifications|`SetValue`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that modified a registry value|`{A98268C1-95F9-5ACD-0000-001025861000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that that modified a registry value|`4624`|
-|process_path|Image|string|File path of the process that that modified a registry value|`C:\WINDOWS\Explorer.EXE`|
-|registry_key_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Notifications\Data\418A073AA3BC3475`|
-|registry_key_details|Details|string|Details added to the registry key|`Binary Data`|
+|process_file_path|Image|string|File path of the process that that modified a registry value|`C:\WINDOWS\Explorer.EXE`|
+|registry_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Notifications\Data\418A073AA3BC3475`|
+|registry_value|Details|string|Details added to the registry key|`Binary Data`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-13-registryevent-value-set)

--- a/data_dictionaries/windows/sysmon/events/event-14.md
+++ b/data_dictionaries/windows/sysmon/events/event-14.md
@@ -9,11 +9,11 @@
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|registry event. Registry key and value renamed|`RenameKey`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that renamed a registry value and key|`{A98268C1-95F9-5ACD-0000-001025861000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that renamed a registry value and key|`4624`|
-|process_path|Image|string|File path of the process that renamed a registry value and key|`C:\WINDOWS\Explorer.EXE`|
-|registry_key_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\New Key #1`|
+|process_file_path|Image|string|File path of the process that renamed a registry value and key|`C:\WINDOWS\Explorer.EXE`|
+|registry_path|TargetObject|string|complete path of the registry key|`HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\New Key #1`|
 |registry_key_new_name|NewName|string|new name of the registry key|`\REGISTRY\MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\hello`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-15.md
+++ b/data_dictionaries/windows/sysmon/events/event-15.md
@@ -12,7 +12,7 @@ This event logs when a **named file stream is created**, and it generates events
 |process_guid|ProcessGuid|string|Process Guid of the process that created the named file stream|`{A98268C1-A8A0-5ACD-0000-001087DEBF00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the named file stream|`6972`|
 |process_file_path|Image|string|File path of the process that created the named file stream|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
-|file_name|TargetFilename|string|Name of the file|`C:\Users\wardog\Downloads\a0fa35bc5badf505f803921f0fe40971-4cf6bad280c7b66e21bb8e96ffe2f968ca460e0d.zip:Zone.Identifier`|
+|file_path|TargetFilename|string|Name of the file|`C:\Users\wardog\Downloads\a0fa35bc5badf505f803921f0fe40971-4cf6bad280c7b66e21bb8e96ffe2f968ca460e0d.zip:Zone.Identifier`|
 |file_creation_time|CreationUtcTime|date|File download time|`4/11/18 6:18`|
 |TBD|Hash|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=F897DA14CF93C872CE821F549C34B848E345C8AC, MD5=697C69E7BB023075F14BC0BE25B875D8, SHA256=3157F3E7A854A13A40FFC79472C319E5B7C744B50D869D6E45F40CD4218539C5, IMPHASH=00000000000000000000000000000000`|
 

--- a/data_dictionaries/windows/sysmon/events/event-15.md
+++ b/data_dictionaries/windows/sysmon/events/event-15.md
@@ -8,10 +8,10 @@ This event logs when a **named file stream is created**, and it generates events
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the named file stream|`{A98268C1-A8A0-5ACD-0000-001087DEBF00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the named file stream|`6972`|
-|process_path|Image|string|File path of the process that created the named file stream|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
+|process_file_path|Image|string|File path of the process that created the named file stream|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
 |file_name|TargetFilename|string|Name of the file|`C:\Users\wardog\Downloads\a0fa35bc5badf505f803921f0fe40971-4cf6bad280c7b66e21bb8e96ffe2f968ca460e0d.zip:Zone.Identifier`|
 |file_creation_time|CreationUtcTime|date|File download time|`4/11/18 6:18`|
 |TBD|Hash|string|hash is a full hash of the file with the algorithms in the HashType field|`SHA1=F897DA14CF93C872CE821F549C34B848E345C8AC, MD5=697C69E7BB023075F14BC0BE25B875D8, SHA256=3157F3E7A854A13A40FFC79472C319E5B7C744B50D869D6E45F40CD4218539C5, IMPHASH=00000000000000000000000000000000`|

--- a/data_dictionaries/windows/sysmon/events/event-16.md
+++ b/data_dictionaries/windows/sysmon/events/event-16.md
@@ -7,7 +7,7 @@ This event logs when the local **sysmon configuration is updated**.
 ## Data Dictionary
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |sysmon_configuration|Configuration|string|name of the sysmon config file being updated|`C:\Tools\sysmon_config\StartLogging.xml`|
 |sysmon_configuration_hash|ConfigurationFileHash|string|hash (SHA1) of the sysmon config file being updated|`SHA1=647B4A564FA2684252EFB1EA550A06EC432418C8`|
 

--- a/data_dictionaries/windows/sysmon/events/event-17.md
+++ b/data_dictionaries/windows/sysmon/events/event-17.md
@@ -9,11 +9,11 @@ This event generates when a **named pipe is created**. Malware often uses named 
 |---|---|---|---|---|
 |event_type|EventType|string|TBD|`[CreatePipe]{.underline}`|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:21`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:21`|
 |process_guid|ProcessGuid|string|Process Guid of the process that created the pipe|`{A98268C1-A968-5ACD-0000-0010BD4EC200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that created the pipe|`1224`|
 |pipe_name|PipeName|string|Name of the pipe created|`Anonymous Pipe`|
-|process_path|Image|string|File path of the process that created the pipe|`C:\WINDOWS\system32\cmd.exe`|
+|process_file_path|Image|string|File path of the process that created the pipe|`C:\WINDOWS\system32\cmd.exe`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-17-pipeevent-pipe-created)

--- a/data_dictionaries/windows/sysmon/events/event-18.md
+++ b/data_dictionaries/windows/sysmon/events/event-18.md
@@ -9,11 +9,11 @@ This event logs when a **named pipe connection** is made between a client and a 
 |---|---|---|---|---|
 |event_type|EventType|string|TBD|`[CreatePipe]{.underline}`|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
 |process_guid|ProcessGuid|string|Process Guid of the process that connected the pipe|`{A98268C1-959E-5ACD-0000-0010236E0300}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that connected the pipe|`1896`|
 |pipe_name|PipeName|string|Name of the pipe connecged|`\srvsvc`|
-|process_path|Image|string|File path of the process that connected the pipe|`C:\WINDOWS\system32\wbem\wmiprvse.exe`|
+|process_file_path|Image|string|File path of the process that connected the pipe|`C:\WINDOWS\system32\wbem\wmiprvse.exe`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-18-pipeevent-pipe-connected)

--- a/data_dictionaries/windows/sysmon/events/event-19.md
+++ b/data_dictionaries/windows/sysmon/events/event-19.md
@@ -9,7 +9,7 @@ When a **WMI event filter is registered**, which is a method used by malware to 
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|wmievent type|`WmiFilterEvent`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`2018-09-11 23:12:46.606`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`2018-09-11 23:12:46.606`|
 |wmi_operation|Operation|string|wmievent filter operation|`Created`|
 |user_name|User|string|user that created the wmi filter|`DESKTOP-LFD11QP\pedro`|
 |wmi_namespace|EventNamespace|string|event namespace where the wmi clas|`root\CimV2`|

--- a/data_dictionaries/windows/sysmon/events/event-2.md
+++ b/data_dictionaries/windows/sysmon/events/event-2.md
@@ -12,7 +12,7 @@ The change **file creation time** event is registered when a file creation time 
 |process_guid|ProcessGuid|string|Process Guid of the process that changed the file creation time|`{A98268C1-975A-5ACD-0000-0010DB073A00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process changing the file creation time|`1252`|
 |process_file_path|Image|string|File path of the process that changed the file creation time|`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`|
-|file_name|TargetFilename|string|full path name of the file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
+|file_path|TargetFilename|string|full path name of the file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
 |file_creation_time|CreationUtcTime|date|new creation time of the file|`11/13/17 16:57`|
 |file_previous_creation_time|PreviousCreationUtcTime|date|previous creation time of the file|`4/11/18 5:04`|
 

--- a/data_dictionaries/windows/sysmon/events/event-2.md
+++ b/data_dictionaries/windows/sysmon/events/event-2.md
@@ -8,13 +8,13 @@ The change **file creation time** event is registered when a file creation time 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:04`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:04`|
 |process_guid|ProcessGuid|string|Process Guid of the process that changed the file creation time|`{A98268C1-975A-5ACD-0000-0010DB073A00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process changing the file creation time|`1252`|
-|process_path|Image|string|File path of the process that changed the file creation time|`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`|
+|process_file_path|Image|string|File path of the process that changed the file creation time|`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`|
 |file_name|TargetFilename|string|full path name of the file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
-|file_date_creation|CreationUtcTime|date|new creation time of the file|`11/13/17 16:57`|
-|file_previous_date_creation|PreviousCreationUtcTime|date|previous creation time of the file|`4/11/18 5:04`|
+|file_creation_time|CreationUtcTime|date|new creation time of the file|`11/13/17 16:57`|
+|file_previous_creation_time|PreviousCreationUtcTime|date|previous creation time of the file|`4/11/18 5:04`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-2-a-process-changed-a-file-creation-time)

--- a/data_dictionaries/windows/sysmon/events/event-20.md
+++ b/data_dictionaries/windows/sysmon/events/event-20.md
@@ -9,7 +9,7 @@ This event logs the **registration of WMI consumers**, recording the consumer na
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|wmievent type|`WmiConsumerEvent`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`2018-09-11 23:12:46.606`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`2018-09-11 23:12:46.606`|
 |wmi_operation|Operation|string|wmievent filter operation|`Created`|
 |user_name|User|string|user that created the wmi  consumer|`DESKTOP-LFD11QP\pedro`|
 |wmi_consumer_name|Name|string|name of the consumer created|`Updater`|

--- a/data_dictionaries/windows/sysmon/events/event-21.md
+++ b/data_dictionaries/windows/sysmon/events/event-21.md
@@ -9,7 +9,7 @@ When a consumer **binds to a filter**, this event logs the consumer name and fil
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
 |event_type|EventType|string|wmievent type|`WmiBindingEvent`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`2018-09-12 00:47:16.997`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`2018-09-12 00:47:16.997`|
 |wmi_operation|Operation|string|wmievent filter operation|`Created`|
 |user_name|User|string|user that created the wmi filter|`DESKTOP-LFD11QP\pedro`|
 |wmi_consumer_path|Consumer|string|Consumer created to bind|`CommandLineEventConsumer.Name=\"Updater\"`|

--- a/data_dictionaries/windows/sysmon/events/event-22.md
+++ b/data_dictionaries/windows/sysmon/events/event-22.md
@@ -11,7 +11,7 @@ This event generates when a process executes a **DNS query**, whether the result
 |event_creation_time|UtcTime|date|Time in UTC when event was created|`2019-06-12 00:57:55.254`|
 |process_guid|ProcessGuid|string|Process Guid of the process that executed the DNS query|`{A98268C1-4DDF-5D00-0000-00102D794100}`|
 |process_id|ProcessId|string|Process id of the process that executed the DNS query|`416`|
-|dst_host_name|QueryName|string|DNS query name|`chrome.google.com`|
+|dns_query_name|QueryName|string|DNS query name|`chrome.google.com`|
 |dns_response_code|QueryStatus|string|DNS query status|`0`|
 |dns_response_name|QueryResults|string|DNS query results|`type: 5 www3.l.google.com;172.217.7.206;`|
 |process_file_path|Image|string|The full path related to the process that executed the DNS query|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|

--- a/data_dictionaries/windows/sysmon/events/event-22.md
+++ b/data_dictionaries/windows/sysmon/events/event-22.md
@@ -8,13 +8,13 @@ This event generates when a process executes a **DNS query**, whether the result
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`2019-06-12 00:57:55.254`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`2019-06-12 00:57:55.254`|
 |process_guid|ProcessGuid|string|Process Guid of the process that executed the DNS query|`{A98268C1-4DDF-5D00-0000-00102D794100}`|
 |process_id|ProcessId|string|Process id of the process that executed the DNS query|`416`|
 |dst_host_name|QueryName|string|DNS query name|`chrome.google.com`|
-|dns_query_status|QueryStatus|string|DNS query status|`0`|
-|dns_query_results|QueryResults|string|DNS query results|`type: 5 www3.l.google.com;172.217.7.206;`|
-|process_path|Image|string|The full path related to the process that executed the DNS query|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
+|dns_response_code|QueryStatus|string|DNS query status|`0`|
+|dns_response_name|QueryResults|string|DNS query results|`type: 5 www3.l.google.com;172.217.7.206;`|
+|process_file_path|Image|string|The full path related to the process that executed the DNS query|`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-22-dnsevent-dns-query)

--- a/data_dictionaries/windows/sysmon/events/event-23.md
+++ b/data_dictionaries/windows/sysmon/events/event-23.md
@@ -13,7 +13,7 @@ This event logs when a **file is deleted** by a process.
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that deleted the file|`1896`|
 |process_file_path|Image|string|File path of the process that deleted the file|`C:\WINDOWS\system32\explorer.exe`|
 |user_name|User|string|Name of the account who deleted the file.|`DESKTOP-WARDOG\wardog`|
-|file_name|TargetFilename|string|full path name of the deleted file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
+|file_path|TargetFilename|string|full path name of the deleted file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
 |TBD|Hashes|string|Hashes captured by sysmon driver of the deleted file|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|
 |TBD|IsExecutable|bool|TBD|`TBD`|
 |TBD|Archived|string|States if the file was archived when deleted|`True`|

--- a/data_dictionaries/windows/sysmon/events/event-23.md
+++ b/data_dictionaries/windows/sysmon/events/event-23.md
@@ -8,10 +8,10 @@ This event logs when a **file is deleted** by a process.
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 6:28`|
 |process_guid|ProcessGuid|string|Process Guid of the process that deleted the file|`{A98268C1-959E-5ACD-0000-0010236E0300}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that deleted the file|`1896`|
-|process_path|Image|string|File path of the process that deleted the file|`C:\WINDOWS\system32\explorer.exe`|
+|process_file_path|Image|string|File path of the process that deleted the file|`C:\WINDOWS\system32\explorer.exe`|
 |user_name|User|string|Name of the account who deleted the file.|`DESKTOP-WARDOG\wardog`|
 |file_name|TargetFilename|string|full path name of the deleted file|`C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp`|
 |TBD|Hashes|string|Hashes captured by sysmon driver of the deleted file|`SHA1=B0BF5AC2E81BBF597FAD5F349FEEB32CAC449FA2, MD5=6A255BEBF3DBCD13585538ED47DBAFD7, SHA256=4668BB2223FFB983A5F1273B9E3D9FA2C5CE4A0F1FB18CA5C1B285762020073C, IMPHASH=2505BD03D7BD285E50CE89CEC02B333B`|

--- a/data_dictionaries/windows/sysmon/events/event-3.md
+++ b/data_dictionaries/windows/sysmon/events/event-3.md
@@ -8,22 +8,22 @@ The **network connection** event logs TCP/UDP connections on the machine. It is 
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:29`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:29`|
 |process_guid|ProcessGuid|string|Process Guid of the process that made the network connection|`{A98268C1-957F-5ACD-0000-0010EB030000}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that made the network connection|`4`|
-|process_path|Image|string|File path of the process that made the network connection|`System`|
+|process_file_path|Image|string|File path of the process that made the network connection|`System`|
 |user_name|User|string|Name of the account who made the network connection. It usually containes domain name and user name|`NT AUTHORITY\SYSTEM`|
 |network_protocol|Protocol|string|Protocol being used for the network connection|`udp`|
-|network_connection_initiated|Initiated|boolean|Indicated process initiated tcp connection|`FALSE`|
-|src_is_ipv6|SourceIsIpv6|boolean|is the source ip an Ipv6|`FALSE`|
+|network_initiated|Initiated|boolean|Indicated process initiated tcp connection|`FALSE`|
+|src_ip_is_ipv6|SourceIsIpv6|boolean|is the source ip an Ipv6|`FALSE`|
 |src_ip_addr|SourceIp|ip|source ip address that made the network connection|`192.168.64.255`|
-|src_host_name|SourceHostname|string|name of the host that made the network connection|`computer_name or none for broadcast`|
-|src_port|SourcePort|integer|source port number|`138`|
+|src_dvc_hostname|SourceHostname|string|name of the host that made the network connection|`computer_name or none for broadcast`|
+|src_port_number|SourcePort|integer|source port number|`138`|
 |src_port_name|SourcePortName|string|name of the source port being used (i.e. netbios-dgm)|`netbios-dgm`|
-|dst_is_ipv6|DestinationIsIpv6|boolean|is the destination ip an Ipv6|`C:\Windows\System32\cmd.exe`|
+|dst_ip_is_ipv6|DestinationIsIpv6|boolean|is the destination ip an Ipv6|`C:\Windows\System32\cmd.exe`|
 |dst_ip_addr|DestinationIp|ip|ip address destination|`192.168.64.135`|
-|dst_host_name|DestinationHostname|string|name of the host that received the network connection|`DC-WD-001`|
-|dst_port|DestinationPort|integer|destination port number|`138`|
+|dst_dvc_hostname|DestinationHostname|string|name of the host that received the network connection|`DC-WD-001`|
+|dst_port_number|DestinationPort|integer|destination port number|`138`|
 |dst_port_name|DestinationPortName|string|name of the destination port|`netbios-dgm`|
 
 ## References

--- a/data_dictionaries/windows/sysmon/events/event-4.md
+++ b/data_dictionaries/windows/sysmon/events/event-4.md
@@ -7,7 +7,7 @@ The **service state change** event reports the state of the Sysmon service (star
 ## Data Dictionary
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:36`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:36`|
 |service_state|State|string|sysmon service state (i.e. stopped)|`Stopped`|
 |file_version|Version|string|sysmon version|`7.01`|
 |sysmon_schema_version|SchemaVersion|string|sysmon config schema version|`4`|

--- a/data_dictionaries/windows/sysmon/events/event-5.md
+++ b/data_dictionaries/windows/sysmon/events/event-5.md
@@ -8,10 +8,10 @@ The **process terminate** event reports when a process terminates. It provides t
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:37`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:37`|
 |process_guid|ProcessGuid|string|Process Guid of the process that terminated|`{A98268C1-9ECD-5ACD-0000-0010EF6BAF00}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that terminated|`2428`|
-|process_path|Image|string|File path of the process that terminated|`C:\Windows\System32\backgroundTaskHost.exe`|
+|process_file_path|Image|string|File path of the process that terminated|`C:\Windows\System32\backgroundTaskHost.exe`|
 
 ## References
 * [Sysmon Source](https://docs.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-5-process-terminated)

--- a/data_dictionaries/windows/sysmon/events/event-6.md
+++ b/data_dictionaries/windows/sysmon/events/event-6.md
@@ -8,7 +8,7 @@ The **driver loaded** events provides information about a driver being loaded on
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:21`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:21`|
 |driver_loaded|ImageLoaded|string|full path of the driver loaded|`C:\ProgramData\Microsoft\Windows Defender\Definition Updates{741285CC-BF49-492C-90BE-E84BD6CADD73}\MpKsl4d223a5a.sys`|
 |TBD|Hashes|string|Hashes captured by sysmon driver|`SHA1=38310AD6805DC31D5AA61BE182689D63060ACE94, MD5=BF2513029E231BE96D82F7C3ABFF87F4, SHA256=F6DB64112CC50EEE495E2D7C61B8BDBE757A31B03144B0396615FD38C312824E, IMPHASH=06D4A412CF7F5363C49E629BF34446B3`|
 |driver_is_signed|Signed|boolean|is the driver loaded signed|`TRUE`|

--- a/data_dictionaries/windows/sysmon/events/event-7.md
+++ b/data_dictionaries/windows/sysmon/events/event-7.md
@@ -8,11 +8,11 @@ The **image loaded** event logs when a module is loaded in a specific process. T
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:46`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:46`|
 |process_guid|ProcessGuid|string|Process Guid of the process that loaded the image|`{A98268C1-A12A-5ACD-0000-0010E4C8B300}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that loaded the image|`3532`|
-|process_path|Image|string|File path of the process that loaded the image|`C:\Windows\System32\cmd.exe`|
-|module_loaded|ImageLoaded|string|full path of the image loaded|`C:\Windows\System32\msvcrt.dll`|
+|process_file_path|Image|string|File path of the process that loaded the image|`C:\Windows\System32\cmd.exe`|
+|module_path|ImageLoaded|string|full path of the image loaded|`C:\Windows\System32\msvcrt.dll`|
 |file_version|FileVersion|string|Version of the image loaded|`7.0.16299.125 (WinBuild.160101.0800)`|
 |file_description|Description|string|Description of the image loaded|`Windows NT CRT DLL`|
 |file_product|Product|string|Product name the image loaded belongs to|`Microsoft® Windows® Operating System`|

--- a/data_dictionaries/windows/sysmon/events/event-8.md
+++ b/data_dictionaries/windows/sysmon/events/event-8.md
@@ -8,13 +8,13 @@ The **CreateRemoteThread** event detects when a process creates a thread in anot
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:25`|
 |process_guid|SourceProcessGuid|string|Process Guid of the source process that created a thread in another process|`{A98268C1-9586-5ACD-0000-001070A20000}`|
 |process_id|SourceProcessId|integer|Process ID used by the os to identify the source process that created a thread in another process|`684`|
-|process_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\Windows\System32\csrss.exe`|
+|process_file_path|SourceImage|string|File path of the source process that created a thread in another process|`C:\Windows\System32\csrss.exe`|
 |target_process_guid|TargetProcessGuid|string|Process Guid of the target process|`{A98268C1-9C2E-5ACD-0000-00100266AB00}`|
 |target_process_id|TargetProcessId|integer|Process ID used by the os to identify the target process|`240`|
-|target_process_path|TargetImage|string|File path of the target process|`C:\Windows\System32\cmd.exe`|
+|target_process_file_path|TargetImage|string|File path of the target process|`C:\Windows\System32\cmd.exe`|
 |thread_new_id|NewThreadId|integer|Id of the new thread created in the target process|`2336`|
 |thread_start_address|StartAddress|string|New thread start address|`0x00007FFA356A7E40`|
 |thread_start_module|StartModule|string|Start module determined from thread start address mapping to PEB loaded module list|`C:\WINDOWS\System32\KERNELBASE.dll`|

--- a/data_dictionaries/windows/sysmon/events/event-9.md
+++ b/data_dictionaries/windows/sysmon/events/event-9.md
@@ -8,10 +8,10 @@ The **RawAccessRead** event detects when a process conducts reading operations f
 |Standard Name|Field Name|Type|Description|Sample Value|
 |---|---|---|---|---|
 |tag|RuleName|string|custom tag mapped to event. i.e ATT&CK technique ID|`T1114`|
-|event_date_creation|UtcTime|date|Time in UTC when event was created|`4/11/18 5:51`|
+|event_creation_time|UtcTime|date|Time in UTC when event was created|`4/11/18 5:51`|
 |process_guid|ProcessGuid|string|Process Guid of the process that conducted reading operations from the drive|`{A98268C1-959B-5ACD-0000-0010EFD50200}`|
 |process_id|ProcessId|integer|Process ID used by the os to identify the process that conducted reading operations from the drive|`2708`|
-|process_path|Image|string|File path of the process that conducted reading operations from the drive|`C:\Windows\System32\svchost.exe`|
+|process_file_path|Image|string|File path of the process that conducted reading operations from the drive|`C:\Windows\System32\svchost.exe`|
 |target_device|Device|string|Target device|`\Device\HarddiskVolume2`|
 
 ## References

--- a/source/data_dictionaries/windows/sysmon/events/event-1.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-1.yml
@@ -40,33 +40,33 @@ event_fields:
   description: File path of the process being spawned/created. Considered also the
     child or source process
   sample_value: C:\Windows\System32\conhost.exe
-- standard_name: file_version
+- standard_name: process_file_version
   standard_type: TBD
   name: FileVersion
   type: string
   description: Version of the image associated with the main process (child)
   sample_value: 10.0.16299.15 (WinBuild.160101.0800)
-- standard_name: file_description
+- standard_name: process_file_description
   standard_type: TBD
   name: Description
   type: string
   description: Description of the image associated with the main process (child)
   sample_value: Console Window Host
-- standard_name: file_product
+- standard_name: process_file_product
   standard_type: TBD
   name: Product
   type: string
   description: Product name the image associated with the main process (child) belongs
     to
   sample_value: "Microsoft\xAE Windows\xAE Operating System"
-- standard_name: file_company
+- standard_name: process_file_company
   standard_type: TBD
   name: Company
   type: string
   description: Company name the image associated with the main process (child) belongs
     to
   sample_value: Microsoft Corporation
-- standard_name: file_name_original
+- standard_name: process_file_name_original
   standard_type: TBD
   name: OriginalFileName
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-1.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-1.yml
@@ -15,7 +15,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -33,7 +33,7 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the created process (child)
   sample_value: '4756'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
@@ -79,7 +79,7 @@ event_fields:
   description: Arguments which were passed to the executable associated with the main
     process
   sample_value: ??\C:\WINDOWS\system32\conhost.exe 0xffffffff -ForceV1
-- standard_name: file_current_directory
+- standard_name: process_file_directory
   standard_type: TBD
   name: CurrentDirectory
   type: string
@@ -138,7 +138,7 @@ event_fields:
   type: integer
   description: Process ID of the process that spawned/created the main process (child)
   sample_value: '240'
-- standard_name: process_parent_path
+- standard_name: process_parent_file_path
   standard_type: TBD
   name: ParentImage
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-10.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-10.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -46,7 +46,7 @@ event_fields:
   description: ID of the specific thread inside of the source process that opened
     another process
   sample_value: '2804'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: SourceImage
   type: string
@@ -64,7 +64,7 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the target process
   sample_value: '2288'
-- standard_name: target_process_path
+- standard_name: target_process_file_path
   standard_type: TBD
   name: TargetImage
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-11.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-11.yml
@@ -39,7 +39,7 @@ event_fields:
   type: string
   description: File path of the process that created the file
   sample_value: C:\WINDOWS\System32\svchost.exe
-- standard_name: file_name
+- standard_name: file_path
   standard_type: TBD
   name: TargetFilename
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-11.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-11.yml
@@ -14,7 +14,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -33,7 +33,7 @@ event_fields:
   description: Process ID used by the os to identify the process that created the
     file (child)
   sample_value: '1044'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
@@ -45,7 +45,7 @@ event_fields:
   type: string
   description: Name of the file
   sample_value: C:\Windows\Prefetch\CONHOST.EXE-1F3E9D7E.pf
-- standard_name: file_date_creation
+- standard_name: file_creation_time
   standard_type: TBD
   name: CreationUtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-12.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-12.yml
@@ -19,7 +19,7 @@ event_fields:
   type: string
   description: registry event. Either Create or Delete
   sample_value: CreateKey
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -38,13 +38,13 @@ event_fields:
   description: Process ID used by the os to identify the process that created or deleted
     a registry key
   sample_value: '2052'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
   description: File path of the process that created or deleted a registry key
   sample_value: C:\Program Files\Common Files\Microsoft Shared\ClickToRun\OfficeClickToRun.exe
-- standard_name: registry_key_path
+- standard_name: registry_path
   standard_type: TBD
   name: TargetObject
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-13.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-13.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: registry event. Registry values modifications
   sample_value: SetValue
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -37,19 +37,19 @@ event_fields:
   description: Process ID used by the os to identify the process that that modified
     a registry value
   sample_value: '4624'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
   description: File path of the process that that modified a registry value
   sample_value: C:\WINDOWS\Explorer.EXE
-- standard_name: registry_key_path
+- standard_name: registry_path
   standard_type: TBD
   name: TargetObject
   type: string
   description: complete path of the registry key
   sample_value: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Notifications\Data\418A073AA3BC3475
-- standard_name: registry_key_details
+- standard_name: registry_value
   standard_type: TBD
   name: Details
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-14.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-14.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: registry event. Registry key and value renamed
   sample_value: RenameKey
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -37,13 +37,13 @@ event_fields:
   description: Process ID used by the os to identify the process that renamed a registry
     value and key
   sample_value: '4624'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
   description: File path of the process that renamed a registry value and key
   sample_value: C:\WINDOWS\Explorer.EXE
-- standard_name: registry_key_path
+- standard_name: registry_path
   standard_type: TBD
   name: TargetObject
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-15.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-15.yml
@@ -16,7 +16,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -35,7 +35,7 @@ event_fields:
   description: Process ID used by the os to identify the process that created the
     named file stream
   sample_value: '6972'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-15.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-15.yml
@@ -41,7 +41,7 @@ event_fields:
   type: string
   description: File path of the process that created the named file stream
   sample_value: C:\Program Files (x86)\Google\Chrome\Application\chrome.exe
-- standard_name: file_name
+- standard_name: file_path
   standard_type: TBD
   name: TargetFilename
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-16.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-16.yml
@@ -5,7 +5,7 @@ log_source: sysmon
 event_code: '16'
 event_version: '4.32'
 event_fields:
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-17.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-17.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -43,7 +43,7 @@ event_fields:
   type: string
   description: Name of the pipe created
   sample_value: Anonymous Pipe
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-18.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-18.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -43,7 +43,7 @@ event_fields:
   type: string
   description: Name of the pipe connecged
   sample_value: \srvsvc
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-19.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-19.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: wmievent type
   sample_value: WmiFilterEvent
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-2.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-2.yml
@@ -16,7 +16,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -35,7 +35,7 @@ event_fields:
   description: Process ID used by the os to identify the process changing the file
     creation time
   sample_value: '1252'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
@@ -47,13 +47,13 @@ event_fields:
   type: string
   description: full path name of the file
   sample_value: C:\Users\wardog\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\7G23PHTPHSQ3S2RVKKPS.temp
-- standard_name: file_date_creation
+- standard_name: file_creation_time
   standard_type: TBD
   name: CreationUtcTime
   type: date
   description: new creation time of the file
   sample_value: 11/13/17 16:57
-- standard_name: file_previous_date_creation
+- standard_name: file_previous_creation_time
   standard_type: TBD
   name: PreviousCreationUtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-2.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-2.yml
@@ -41,7 +41,7 @@ event_fields:
   type: string
   description: File path of the process that changed the file creation time
   sample_value: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-- standard_name: file_name
+- standard_name: file_path
   standard_type: TBD
   name: TargetFilename
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-20.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-20.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: wmievent type
   sample_value: WmiConsumerEvent
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-21.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-21.yml
@@ -18,7 +18,7 @@ event_fields:
   type: string
   description: wmievent type
   sample_value: WmiBindingEvent
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-22.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-22.yml
@@ -12,7 +12,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -36,19 +36,19 @@ event_fields:
   type: string
   description: DNS query name
   sample_value: chrome.google.com
-- standard_name: dns_query_status
+- standard_name: dns_response_code
   standard_type: TBD
   name: QueryStatus
   type: string
   description: DNS query status
   sample_value: '0'
-- standard_name: dns_query_results
+- standard_name: dns_response_name
   standard_type: TBD
   name: QueryResults
   type: string
   description: DNS query results
   sample_value: 'type: 5 www3.l.google.com;172.217.7.206;'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-22.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-22.yml
@@ -30,7 +30,7 @@ event_fields:
   type: string
   description: Process id of the process that executed the DNS query
   sample_value: '416'
-- standard_name: dst_host_name
+- standard_name: dns_query_name
   standard_type: TBD
   name: QueryName
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-23.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-23.yml
@@ -11,7 +11,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -30,7 +30,7 @@ event_fields:
   description: Process ID used by the os to identify the process that deleted the
     file
   sample_value: '1896'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-23.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-23.yml
@@ -42,7 +42,7 @@ event_fields:
   type: string
   description: Name of the account who deleted the file.
   sample_value: DESKTOP-WARDOG\wardog
-- standard_name: file_name
+- standard_name: file_path
   standard_type: TBD
   name: TargetFilename
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-3.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-3.yml
@@ -14,7 +14,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -33,7 +33,7 @@ event_fields:
   description: Process ID used by the os to identify the process that made the network
     connection
   sample_value: '4'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
@@ -52,13 +52,13 @@ event_fields:
   type: string
   description: Protocol being used for the network connection
   sample_value: udp
-- standard_name: network_connection_initiated
+- standard_name: network_initiated
   standard_type: TBD
   name: Initiated
   type: boolean
   description: Indicated process initiated tcp connection
   sample_value: 'FALSE'
-- standard_name: src_is_ipv6
+- standard_name: src_ip_is_ipv6
   standard_type: TBD
   name: SourceIsIpv6
   type: boolean
@@ -70,13 +70,13 @@ event_fields:
   type: ip
   description: source ip address that made the network connection
   sample_value: 192.168.64.255
-- standard_name: src_host_name
+- standard_name: src_dvc_hostname
   standard_type: TBD
   name: SourceHostname
   type: string
   description: name of the host that made the network connection
   sample_value: computer_name or none for broadcast
-- standard_name: src_port
+- standard_name: src_port_number
   standard_type: TBD
   name: SourcePort
   type: integer
@@ -88,7 +88,7 @@ event_fields:
   type: string
   description: name of the source port being used (i.e. netbios-dgm)
   sample_value: netbios-dgm
-- standard_name: dst_is_ipv6
+- standard_name: dst_ip_is_ipv6
   standard_type: TBD
   name: DestinationIsIpv6
   type: boolean
@@ -100,13 +100,13 @@ event_fields:
   type: ip
   description: ip address destination
   sample_value: 192.168.64.135
-- standard_name: dst_host_name
+- standard_name: dst_dvc_hostname
   standard_type: TBD
   name: DestinationHostname
   type: string
   description: name of the host that received the network connection
   sample_value: DC-WD-001
-- standard_name: dst_port
+- standard_name: dst_port_number
   standard_type: TBD
   name: DestinationPort
   type: integer

--- a/source/data_dictionaries/windows/sysmon/events/event-4.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-4.yml
@@ -6,7 +6,7 @@ log_source: sysmon
 event_code: '4'
 event_version: '4.32'
 event_fields:
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-5.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-5.yml
@@ -12,7 +12,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -30,7 +30,7 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the process that terminated
   sample_value: '2428'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-6.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-6.yml
@@ -14,7 +14,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date

--- a/source/data_dictionaries/windows/sysmon/events/event-7.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-7.yml
@@ -16,7 +16,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -34,13 +34,13 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the process that loaded the image
   sample_value: '3532'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string
   description: File path of the process that loaded the image
   sample_value: C:\Windows\System32\cmd.exe
-- standard_name: module_loaded
+- standard_name: module_path
   standard_type: TBD
   name: ImageLoaded
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-8.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-8.yml
@@ -16,7 +16,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -36,7 +36,7 @@ event_fields:
   description: Process ID used by the os to identify the source process that created
     a thread in another process
   sample_value: '684'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: SourceImage
   type: string
@@ -54,7 +54,7 @@ event_fields:
   type: integer
   description: Process ID used by the os to identify the target process
   sample_value: '240'
-- standard_name: target_process_path
+- standard_name: target_process_file_path
   standard_type: TBD
   name: TargetImage
   type: string

--- a/source/data_dictionaries/windows/sysmon/events/event-9.yml
+++ b/source/data_dictionaries/windows/sysmon/events/event-9.yml
@@ -14,7 +14,7 @@ event_fields:
   type: string
   description: custom tag mapped to event. i.e ATT&CK technique ID
   sample_value: T1114
-- standard_name: event_date_creation
+- standard_name: event_creation_time
   standard_type: TBD
   name: UtcTime
   type: date
@@ -34,7 +34,7 @@ event_fields:
   description: Process ID used by the os to identify the process that conducted reading
     operations from the drive
   sample_value: '2708'
-- standard_name: process_path
+- standard_name: process_file_path
   standard_type: TBD
   name: Image
   type: string


### PR DESCRIPTION
I've done a first pass on Sysmon data dictionaries, in order to make them compliant with entities. There are still some issues, listed below:

* No good mapping for OriginalFileName from EventID 1, 7. It's a PE-format special field, but it's still useful.
* No good mapping for Sysmon-specific fields of Event ID 4 (`service_state`, `sysmon_schema_version`), and 16.
* No good mapping for RuleName, present in all events.
* No mapping for thread-related fields from EventID 8, 10.
* No good mapping for TargetDevice from EventID 9.
* Not sure if Event ID 12,13,14's TargetObject should be `registry_key` or `registry_path`.
* No good mapping for EventID 14's TargetObject, since NewName is the `registry_path`, so I went with `registry_path_modified` following the convention of `registry_value_name_modified`
* No mapping for WMI-related fields from EventIDs 19, 20, 21.

Let me know if there are other issues.