### PR TITLE
Added logic to improve Sysmon KQL generation

### DIFF
--- a/resources/scripts/ossemSysmonKQLParser.py
+++ b/resources/scripts/ossemSysmonKQLParser.py
@@ -84,6 +84,7 @@ for item in eventlist:
         field_name = dict()
         field_name['name'] = field['name']
         field_name['index'] = count
+        field_name['type'] = field['inType']
         sysmon_event['events'].append(field_name)
         count += 1
     all_sysmon.append(sysmon_event)
@@ -95,6 +96,17 @@ for sysevent in all_sysmon:
     for field in sysevent['events']:
         if field['name'] not in unique_fields:
             unique_fields.append(field['name'])
+        if (field['type'].startswith("win:UInt") or
+            field['type'].startswith("win:HexInt")):
+            field['type'] = "toint"
+        elif (field['type'] == "win:UnicodeString" or
+              field['type'] == "win:GUID"):
+            field['type'] = "tostring"
+        elif (field['type'] == "win:Boolean"):
+            field['type'] = "tobool"
+        else:
+            field['type'] = "" #make it backwards and forwards compatible so it doesn't break
+
 
 # ******** Open Sysmon KQL Parser template ****************
 sysmon_parser_template = os.path.join(os.path.dirname(__file__), "templates/kql/sysmon_parser.txt")

--- a/resources/scripts/templates/kql/sysmon_parser.txt
+++ b/resources/scripts/templates/kql/sysmon_parser.txt
@@ -24,7 +24,7 @@ let EventData = Event
 let {{event['name']}}_{{event['id']}}{% raw %}=() {
 let processEvents = EventData
 | where EventID == {% endraw %}{{event['id']}}
-| extend {% for field in event['events'] if field['name'] not in ['Hashes','Hash'] %}{{field['name']}}{% raw %} = EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]{% endraw %}{{ ", " if not loop.last else "" }}
+| extend {% for field in event['events'] if field['name'] not in ['Hashes','Hash'] %}{{field['name']}}{% raw %} = {% endraw %}{{field['type']}}{% raw %}(EventDetail.[{% endraw %}{{field['index']}}{% raw %}].["#text"]){% endraw %}{{ ", " if not loop.last else "" }}
 {% endfor -%}
 {% for field in event['events'] -%}
     {% if field['name'] in ['Hashes','Hash'] -%}


### PR DESCRIPTION
The current Sysmon "AllVersions" parser is incredibly slow, probably due to the mv-expand or other run-time inefficiencies. Hence, I prefer to use the "old" static but fast runtime parser.

This PR fixes the issue where all KQL columns generated are of type `dynamic`. This prevents easy joins and other operations which are not allowed on dynamics. 

The code takes the type defined in the XML and performs the correct typecasting when generating the columns. Now, the output looks like this:

```
...
let SYSMONEVENT_IMAGE_LOAD_7=() {
let processEvents = EventData
| where EventID == 7
| extend RuleName = tostring(EventDetail.[0].["#text"]), 
UtcTime = tostring(EventDetail.[1].["#text"]), 
ProcessGuid = tostring(EventDetail.[2].["#text"]), 
ProcessId = toint(EventDetail.[3].["#text"]), 
Image = tostring(EventDetail.[4].["#text"]), 
...
```